### PR TITLE
Start in PreOperational

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Orocos component for control of KUKA robots using RSI.
 The code is based on the ROS control hardware interface in the ROS-Industrial `kuka_experimental` package found [here](https://github.com/ros-industrial/kuka_experimental/tree/indigo-devel/kuka_rsi_hw_interface).
 
 Note that this is a work in progress and breaking changes will occur.
+
+See `./scripts/run.lua` for basic usage. This can be called with `rttlua -i run.lua`.

--- a/scripts/run.lua
+++ b/scripts/run.lua
@@ -1,6 +1,7 @@
 require "rttlib"
 require "rttros"
 
+rttlib.color=true -- Colored console output
 rtt.setLogLevel("Info")
 
 -- Task Context

--- a/scripts/run.lua
+++ b/scripts/run.lua
@@ -12,8 +12,14 @@ depl = tc:getPeer("Deployer")
 -- Interface with ROS:
 depl:import("rtt_ros")
 
--- Load my component
+-- Load RSI component
 depl:import("rtt_rsi")
 depl:loadComponent("rsi", "rtt_rsi::RSIComponent")
 rsi = depl:getPeer("rsi")
+
+-- Set ip address of robot
+robot_ip = rsi:getProperty("local_host")
+robot_port = rsi:getProperty("local_port")
+robot_ip:set("127.0.0.1") -- change this to the IP to connect
+robot_port:set(49152) -- Listening port
 rsi:configure()

--- a/src/RSIComponent.cpp
+++ b/src/RSIComponent.cpp
@@ -16,7 +16,7 @@ class RSIComponent : public RTT::TaskContext
 {
 public:
   RSIComponent(const std::string& name)
-    : RTT::TaskContext(name)
+    : RTT::TaskContext(name, PreOperational)
     , local_host_("127.0.0.1")
     , local_port_(49152)
     , joint_position_(6, 0.0)


### PR DESCRIPTION
The RSI component sets up the UDPServer in the configure hook, so we should probably start in PreOperational to require the configure call. If you don't configure it, it'll just segfault if you accidentally start it.
Also added a little note to run.lua on how to set the IP address and listening port.